### PR TITLE
Update CollectionInterfaceClass.cpp to Win 32 GetTempPath()

### DIFF
--- a/src/Classes/CollectionInterfaceClass.cpp
+++ b/src/Classes/CollectionInterfaceClass.cpp
@@ -360,7 +360,7 @@ std::wstring CollectionInterface::getWritableTempDir(void)
 {
 	// first try the system TEMP
 	std::wstring tempDir(MAX_PATH+1, L'\0');
-	GetTempPath2(MAX_PATH + 1, const_cast<LPWSTR>(tempDir.data()));
+	GetTempPath(MAX_PATH + 1, const_cast<LPWSTR>(tempDir.data()));
 	_wsDeleteTrailingNulls(tempDir);
 
 	// if that fails, try c:\tmp or c:\temp


### PR DESCRIPTION
GetTempPath2() is a Win 11 library, for compatibility prior, change to GetTempPath() for Win32 compatibility.

Peter, this is my first attempt at collaboration on github, so since I'm trying to learn, I'll submit this PR in an effort to learn and contribute. 
I made the change you suggested, had issues, had to delete my local and do a full clone of your code into my github page, and found out I can offer a fix and make the contribution. So here it is.