### PR TITLE
Automation Workflow: rename zipfile to include tag name (version) and use doc/ directory for README and license

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -62,7 +62,7 @@ jobs:
         if((Test-Path -Path arm64\CollectionInterface.dll)) {
             Copy-Item -Path arm64\CollectionInterface.dll -Destination .\CollectionInterface.dll
         }
-        $zipName = "CollectionInterface_${{ matrix.build_platform }}.zip"
+        $zipName = "CollectionInterface_${{ github.ref_name }}_${{ matrix.build_platform }}.zip"
         $filesToZip = "CollectionInterface.dll", ".\docs\"
         Compress-Archive -Path $filesToZip -Destination $zipName
         dir
@@ -71,8 +71,8 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ./CollectionInterface_${{ matrix.build_platform }}.zip
-        asset_name: CollectionInterface_${{ matrix.build_platform }}.zip
+        file: ./CollectionInterface_${{ github.ref_name }}_${{ matrix.build_platform }}.zip
+        asset_name: CollectionInterface_${{ github.ref_name }}_${{ matrix.build_platform }}.zip
         tag: ${{ github.ref }}
         overwrite: true
         body: ${{ github.event.release.body }}

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -49,10 +49,11 @@ jobs:
       working-directory: .
       run: |
         echo "This only runs on a tag, I hope"
-        if(!(Test-Path -Path .\docs)) {
-            New-Item -ItemType Directory -Path .\docs
+        if(!(Test-Path -Path .\doc)) {
+            New-Item -ItemType Directory -Path .\doc
         }
-        Copy-Item -Path README.md -Destination .\docs\
+        Copy-Item -Path README.md -Destination .\doc\
+        Copy-Item -Path license.txt -Destination .\doc\
         if((Test-Path -Path bin64\CollectionInterface.dll)) {
             Copy-Item -Path bin64\CollectionInterface.dll -Destination .\CollectionInterface.dll
         }
@@ -63,7 +64,7 @@ jobs:
             Copy-Item -Path arm64\CollectionInterface.dll -Destination .\CollectionInterface.dll
         }
         $zipName = "CollectionInterface_${{ github.ref_name }}_${{ matrix.build_platform }}.zip"
-        $filesToZip = "CollectionInterface.dll", ".\docs\"
+        $filesToZip = "CollectionInterface.dll", ".\doc\"
         Compress-Archive -Path $filesToZip -Destination $zipName
         dir
     - name: 🎉 Store ${{ matrix.build_platform }} zipfile as asset


### PR DESCRIPTION
- zipfile name based on `${{ github.ref_name }}` 
- README and license into `doc/` instead of `docs/` for better PluginsAdmin compatibility

closes #8