### PR TITLE
Dark Mode

### DIFF
--- a/src/CollectionInterface.cpp
+++ b/src/CollectionInterface.cpp
@@ -17,36 +17,31 @@
 
 #include "PluginDefinition.h"
 
-extern FuncItem funcItem[nbFunc];
-extern NppData nppData;
-
-
 BOOL APIENTRY DllMain(HANDLE hModule, DWORD  reasonForCall, LPVOID /*lpReserved*/)
 {
 	try {
 
 		switch (reasonForCall)
 		{
-			case DLL_PROCESS_ATTACH:
-				pluginInit(hModule);
-				break;
+		case DLL_PROCESS_ATTACH:
+			pluginInit(hModule);
+			break;
 
-			case DLL_PROCESS_DETACH:
-				pluginCleanUp();
-				break;
+		case DLL_PROCESS_DETACH:
+			pluginCleanUp();
+			break;
 
-			case DLL_THREAD_ATTACH:
-				break;
+		case DLL_THREAD_ATTACH:
+			break;
 
-			case DLL_THREAD_DETACH:
-				break;
+		case DLL_THREAD_DETACH:
+			break;
 		}
 	}
 	catch (...) { return FALSE; }
 
-    return TRUE;
+	return TRUE;
 }
-
 
 extern "C" __declspec(dllexport) void setInfo(NppData notpadPlusData)
 {
@@ -54,30 +49,38 @@ extern "C" __declspec(dllexport) void setInfo(NppData notpadPlusData)
 	commandMenuInit();
 }
 
-extern "C" __declspec(dllexport) const TCHAR * getName()
+extern "C" __declspec(dllexport) const TCHAR* getName()
 {
 	return NPP_PLUGIN_NAME;
 }
 
-extern "C" __declspec(dllexport) FuncItem * getFuncsArray(int *nbF)
+extern "C" __declspec(dllexport) FuncItem* getFuncsArray(int* nbF)
 {
 	*nbF = nbFunc;
 	return funcItem;
 }
 
 
-extern "C" __declspec(dllexport) void beNotified(SCNotification *notifyCode)
+extern "C" __declspec(dllexport) void beNotified(SCNotification* notifyCode)
 {
-	switch (notifyCode->nmhdr.code) 
+	switch (notifyCode->nmhdr.code)
 	{
-		case NPPN_SHUTDOWN:
-		{
-			commandMenuCleanUp();
+	case NPPN_DARKMODECHANGED:
+	{
+		if (g_hwndAboutDlg) {
+			::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfHandleChange), reinterpret_cast<LPARAM>(g_hwndAboutDlg));
+			::SetWindowPos(g_hwndAboutDlg, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED); // to redraw titlebar
 		}
-		break;
+	}
+	break;
+	case NPPN_SHUTDOWN:
+	{
+		commandMenuCleanUp();
+	}
+	break;
 
-		default:
-			return;
+	default:
+		return;
 	}
 }
 
@@ -100,6 +103,6 @@ extern "C" __declspec(dllexport) LRESULT messageProc(UINT /*Message*/, WPARAM /*
 #ifdef UNICODE
 extern "C" __declspec(dllexport) BOOL isUnicode()
 {
-    return TRUE;
+	return TRUE;
 }
 #endif //UNICODE

--- a/src/CollectionInterface.cpp
+++ b/src/CollectionInterface.cpp
@@ -67,9 +67,12 @@ extern "C" __declspec(dllexport) void beNotified(SCNotification* notifyCode)
 	{
 	case NPPN_DARKMODECHANGED:
 	{
-		if (g_hwndAboutDlg) {
-			::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfHandleChange), reinterpret_cast<LPARAM>(g_hwndAboutDlg));
-			::SetWindowPos(g_hwndAboutDlg, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED); // to redraw titlebar
+		std::vector<HWND> hw_dlgs = { g_hwndAboutDlg, g_hwndCIDlg };
+		for (auto hw : hw_dlgs) {
+			if (hw) {
+				::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfHandleChange), reinterpret_cast<LPARAM>(hw));
+				::SetWindowPos(hw, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED); // to redraw titlebar
+			}
 		}
 	}
 	break;

--- a/src/Dialogs/AboutDialog.cpp
+++ b/src/Dialogs/AboutDialog.cpp
@@ -29,11 +29,31 @@
 #define BITNESS TEXT("(32 bit)")
 #endif
 
+HWND g_hwndAboutDlg = nullptr;
+
 #pragma warning(push)
 #pragma warning(disable: 4100)
 INT_PTR CALLBACK abtDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 	switch (uMsg) {
 	case WM_INITDIALOG:
+		// follow DarkMode
+		g_hwndAboutDlg = hwndDlg;
+		::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfInit), reinterpret_cast<LPARAM>(g_hwndAboutDlg));
+		if (1) {
+			bool isDM = (bool)::SendMessage(nppData._nppHandle, NPPM_ISDARKMODEENABLED, 0, 0);
+			if (isDM) {
+				NppDarkMode::Colors myColors = { 0 };
+				if (::SendMessage(nppData._nppHandle, NPPM_GETDARKMODECOLORS, sizeof(NppDarkMode::Colors), reinterpret_cast<LPARAM>(&myColors))) {
+					SetHyperlinkRGB(myColors.linkText);
+				}
+				else {
+					SetHyperlinkRGB(RGB(64, 64, 255));
+				}
+			}
+			else {
+				SetHyperlinkRGB(RGB(0, 0, 192));
+			}
+		}
 		ConvertStaticToHyperlink(hwndDlg, IDC_GITHUB);
 		//ConvertStaticToHyperlink(hwndDlg, IDC_README);
 		//Edit_SetText(GetDlgItem(hwndDlg, IDC_VERSION), TEXT("DoxyIt v") VERSION_TEXT TEXT(" ") VERSION_STAGE TEXT(" ") BITNESS);
@@ -70,15 +90,17 @@ INT_PTR CALLBACK abtDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 		case IDOK:
 			EndDialog(hwndDlg, 0);
 			DestroyWindow(hwndDlg);
+			g_hwndAboutDlg = nullptr;
 			return true;
-			case IDC_GITHUB:
-				ShellExecute(hwndDlg, TEXT("open"), TEXT(VERSION_URL), NULL, NULL, SW_SHOWNORMAL);
-				return true;
+		case IDC_GITHUB:
+			ShellExecute(hwndDlg, TEXT("open"), TEXT(VERSION_URL), NULL, NULL, SW_SHOWNORMAL);
+			return true;
 			//case IDC_README:
 			//	ShellExecute(hwndDlg, TEXT("open"), TEXT("https://github.com/dail8859/DoxyIt/blob/v") VERSION_TEXT TEXT("/README.md"), NULL, NULL, SW_SHOWNORMAL);
 			//	return true;
 		}
 	case WM_DESTROY:
+		g_hwndAboutDlg = nullptr;
 		DestroyWindow(hwndDlg);
 		return true;
 	}

--- a/src/Dialogs/CollectionInterfaceDialog.cpp
+++ b/src/Dialogs/CollectionInterfaceDialog.cpp
@@ -28,6 +28,7 @@
 #include <vector>
 #include <CommCtrl.h>
 
+HWND g_hwndCIDlg = nullptr;
 CollectionInterface* pobjCI;
 void _populate_file_cbx(HWND hwndDlg, std::vector<std::wstring>& vsList);
 void _populate_file_cbx(HWND hwndDlg, std::map<std::wstring, std::wstring>& mapURLs, std::map<std::wstring, std::wstring>& mapDisplay);
@@ -40,6 +41,9 @@ INT_PTR CALLBACK ciDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam
 	switch (uMsg) {
 	case WM_INITDIALOG:
 	{
+		// store hwnd
+		g_hwndCIDlg = hwndDlg;
+
 		// Find Center and then position the window:
 
 		// find App center
@@ -87,6 +91,10 @@ INT_PTR CALLBACK ciDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam
 		pobjCI = new CollectionInterface(hParent);
 		//pobjCI->getListsFromJson();
 		_populate_file_cbx(hwndDlg, pobjCI->mapUDL, pobjCI->mapDISPLAY);
+
+		// Follow DarkMode
+		::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfInit), reinterpret_cast<LPARAM>(g_hwndCIDlg));
+
 	}
 
 	return true;
@@ -155,6 +163,7 @@ INT_PTR CALLBACK ciDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam
 		case IDCANCEL:
 			EndDialog(hwndDlg, 0);
 			DestroyWindow(hwndDlg);
+			g_hwndCIDlg = nullptr;
 			delete pobjCI;
 			pobjCI = NULL;
 			return true;
@@ -408,6 +417,7 @@ INT_PTR CALLBACK ciDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam
 	return false;
 	case WM_DESTROY:
 		DestroyWindow(hwndDlg);
+		g_hwndCIDlg = nullptr;
 		return true;
 	}
 	return false;

--- a/src/Dialogs/CollectionInterfaceDialog.cpp
+++ b/src/Dialogs/CollectionInterfaceDialog.cpp
@@ -28,328 +28,305 @@
 #include <vector>
 #include <CommCtrl.h>
 
+
 HWND g_hwndCIDlg = nullptr;
 CollectionInterface* pobjCI;
 void _populate_file_cbx(HWND hwndDlg, std::vector<std::wstring>& vsList);
 void _populate_file_cbx(HWND hwndDlg, std::map<std::wstring, std::wstring>& mapURLs, std::map<std::wstring, std::wstring>& mapDisplay);
 std::wstring _get_tab_category_wstr(HWND hwndDlg, int idcTabCtrl);
 
+// for tab control in DarkMode:
+bool g_IsDarkMode = false;
+const int g_ci_dark_subclass = 118;	// Don uses 42 for his DarkMode subclassing; the id+callback must be unique, but I'll use my own "magic number"
+static LRESULT CALLBACK cbTabSubclass(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData);
+NppDarkMode::Colors myColors = { 0 };
+NppDarkMode::Brushes myBrushes(myColors);
+NppDarkMode::Pens myPens(myColors);
+
+
 #pragma warning(push)
 #pragma warning(disable: 4100)
 INT_PTR CALLBACK ciDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 	static bool didDownload = false;
-	static HBRUSH hBgBrush = nullptr;
 	static COLORREF rgbTextFG = 0, rgbTextBG = 0;
-	static bool isDM = false;
-	static NppDarkMode::Colors myColors = { 0 };
+	static HWND hwndTab = nullptr;
 	switch (uMsg) {
-	case WM_INITDIALOG:
-	{
-		// store hwnd
-		g_hwndCIDlg = hwndDlg;
+		case WM_INITDIALOG:
+		{
+			// store hwnd
+			g_hwndCIDlg = hwndDlg;
 
-		// determine dark mode
-		isDM = (bool)::SendMessage(nppData._nppHandle, NPPM_ISDARKMODEENABLED, 0, 0);
-		if (isDM) {
-			::SendMessage(nppData._nppHandle, NPPM_GETDARKMODECOLORS, sizeof(NppDarkMode::Colors), reinterpret_cast<LPARAM>(&myColors));
+			if (!hwndTab)
+				hwndTab = GetDlgItem(g_hwndCIDlg, IDC_CI_TABCTRL);
+
+			// determine dark mode
+			g_IsDarkMode = (bool)::SendMessage(nppData._nppHandle, NPPM_ISDARKMODEENABLED, 0, 0);
+			if (g_IsDarkMode) {
+				::SendMessage(nppData._nppHandle, NPPM_GETDARKMODECOLORS, sizeof(NppDarkMode::Colors), reinterpret_cast<LPARAM>(&myColors));
+				myBrushes.change(myColors);
+				myPens.change(myColors);
+
+				::SetWindowSubclass(hwndTab, cbTabSubclass, g_ci_dark_subclass, 0);
+			}
+
+			// color based on background
+			rgbTextFG = g_IsDarkMode ? myColors.text : RGB(0, 0, 0);
+			rgbTextBG = g_IsDarkMode ? myColors.background : RGB(240, 240, 240);
+
+			// Follow DarkMode
+			::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfInit), reinterpret_cast<LPARAM>(g_hwndCIDlg));
+
+			// Find Center and then position the window:
+
+			// find App center
+			RECT rc;
+			HWND hParent = GetParent(hwndDlg);
+			::GetClientRect(hParent, &rc);
+			POINT center;
+			int w = rc.right - rc.left;
+			int h = rc.bottom - rc.top;
+			center.x = rc.left + w / 2;
+			center.y = rc.top + h / 2;
+			::ClientToScreen(hParent, &center);
+
+			// and position dialog
+			RECT dlgRect;
+			::GetClientRect(hwndDlg, &dlgRect);
+			int x = center.x - (dlgRect.right - dlgRect.left) / 2;
+			int y = center.y - (dlgRect.bottom - dlgRect.top) / 2;
+			::SetWindowPos(hwndDlg, HWND_TOP, x, y, (dlgRect.right - dlgRect.left), (dlgRect.bottom - dlgRect.top), SWP_SHOWWINDOW);
+
+			// populate Category list into the tab bar: "INSERTITEM" means RightToLeft, because it inserts it before the earlier tab.
+			std::wstring ws;
+			TCITEM pop;
+			pop.mask = TCIF_TEXT;
+			ws = L"Theme"; pop.cchTextMax = static_cast<int>(ws.size()); pop.pszText = const_cast<LPWSTR>(ws.data());
+			::SendDlgItemMessage(hwndDlg, IDC_CI_TABCTRL, TCM_INSERTITEM, 0, reinterpret_cast<LPARAM>(&pop));
+			ws = L"FunctionList"; pop.cchTextMax = static_cast<int>(ws.size()); pop.pszText = const_cast<LPWSTR>(ws.data());
+			::SendDlgItemMessage(hwndDlg, IDC_CI_TABCTRL, TCM_INSERTITEM, 0, reinterpret_cast<LPARAM>(&pop));
+			ws = L"AutoCompletion"; pop.cchTextMax = static_cast<int>(ws.size()); pop.pszText = const_cast<LPWSTR>(ws.data());
+			::SendDlgItemMessage(hwndDlg, IDC_CI_TABCTRL, TCM_INSERTITEM, 0, reinterpret_cast<LPARAM>(&pop));
+			ws = L"UDL"; pop.cchTextMax = static_cast<int>(ws.size()); pop.pszText = const_cast<LPWSTR>(ws.data());
+			::SendDlgItemMessage(hwndDlg, IDC_CI_TABCTRL, TCM_INSERTITEM, 0, reinterpret_cast<LPARAM>(&pop));
+			::SendDlgItemMessage(hwndDlg, IDC_CI_TABCTRL, TCM_SETCURSEL, 0, 0);
+
+			// disable options
+			HWND hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC);
+			EnableWindow(hwCHK, FALSE);	// ShowWindow(hwCHK, SW_HIDE);
+			hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL);
+			EnableWindow(hwCHK, FALSE);	// ShowWindow(hwCHK, SW_HIDE);
+
+			// set progress bar
+			::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 0, 0);
+			Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), L"READY");
+
+			pobjCI = new CollectionInterface(hParent);
+			//pobjCI->getListsFromJson();
+			_populate_file_cbx(hwndDlg, pobjCI->mapUDL, pobjCI->mapDISPLAY);
+
+			// make sure everything is up-to-date
+			::UpdateWindow(hwndTab);
+			::UpdateWindow(g_hwndCIDlg);
 		}
 
-		// TODO: brush based on background
-		rgbTextFG = isDM ? myColors.text : RGB(0, 0, 0);
-		rgbTextBG = isDM ? myColors.background : RGB(240, 240, 240);
-		hBgBrush = CreateSolidBrush(rgbTextBG);
+		return true;
+		case WM_COMMAND:
+			switch (LOWORD(wParam)) {
+				case IDOK:
+				case IDC_CI_BTN_DONE:
+					if (didDownload) {
+						int ans = ::MessageBox(hwndDlg, L"Would you like to restart now?", L"Restart Needed", MB_YESNOCANCEL);
+						switch (ans) {
+							case IDYES:
+							{
+								STARTUPINFOW si;
+								PROCESS_INFORMATION pi;
 
-		// Find Center and then position the window:
+								ZeroMemory(&si, sizeof(si));
+								si.cb = sizeof(si);
+								ZeroMemory(&pi, sizeof(pi));
 
-		// find App center
-		RECT rc;
-		HWND hParent = GetParent(hwndDlg);
-		::GetClientRect(hParent, &rc);
-		POINT center;
-		int w = rc.right - rc.left;
-		int h = rc.bottom - rc.top;
-		center.x = rc.left + w / 2;
-		center.y = rc.top + h / 2;
-		::ClientToScreen(hParent, &center);
+								wchar_t cmd[MAX_PATH];
+								swprintf_s(cmd, L"cmd /C ECHO Wait for old Notepad++ to close before launching new copy... & TIMEOUT /T 6 && START \"\" %s", GetCommandLineW());
+								//::MessageBox(NULL, cmd, L"Command to launch:", MB_OK);
+								// If I want to create a persistent console (`cmd /K`), use CREATE_NEW_CONSOLE
+								// if it doesn't need a persistent console (`cmd /C`), use DETACHED_PROCESS
+								//	either one will outlive the parent, so File>Exit will work
+								if (CreateProcessW(nullptr, cmd, nullptr, nullptr, FALSE, CREATE_NEW_CONSOLE, nullptr, nullptr, &si, &pi)) {
+									CloseHandle(pi.hProcess);
+									CloseHandle(pi.hThread);
 
-		// and position dialog
-		RECT dlgRect;
-		::GetClientRect(hwndDlg, &dlgRect);
-		int x = center.x - (dlgRect.right - dlgRect.left) / 2;
-		int y = center.y - (dlgRect.bottom - dlgRect.top) / 2;
-		::SetWindowPos(hwndDlg, HWND_TOP, x, y, (dlgRect.right - dlgRect.left), (dlgRect.bottom - dlgRect.top), SWP_SHOWWINDOW);
+									HWND hParent = GetParent(hwndDlg);
+									SendMessage(hParent, NPPM_MENUCOMMAND, 0, IDM_FILE_EXIT);
+								}
+								else {
+									DWORD errNum = GetLastError();
+									LPWSTR messageBuffer = nullptr;
+									size_t size = FormatMessageW(
+										FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+										NULL,
+										errNum,
+										MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+										(LPWSTR)&messageBuffer,
+										0,
+										NULL
+									);
 
-		// populate Category list into the tab bar: "INSERTITEM" means RightToLeft, because it inserts it before the earlier tab.
-		std::wstring ws;
-		TCITEM pop;
-		pop.mask = TCIF_TEXT;
-		ws = L"Theme"; pop.cchTextMax = static_cast<int>(ws.size()); pop.pszText = const_cast<LPWSTR>(ws.data());
-		::SendDlgItemMessage(hwndDlg, IDC_CI_TABCTRL, TCM_INSERTITEM, 0, reinterpret_cast<LPARAM>(&pop));
-		ws = L"FunctionList"; pop.cchTextMax = static_cast<int>(ws.size()); pop.pszText = const_cast<LPWSTR>(ws.data());
-		::SendDlgItemMessage(hwndDlg, IDC_CI_TABCTRL, TCM_INSERTITEM, 0, reinterpret_cast<LPARAM>(&pop));
-		ws = L"AutoCompletion"; pop.cchTextMax = static_cast<int>(ws.size()); pop.pszText = const_cast<LPWSTR>(ws.data());
-		::SendDlgItemMessage(hwndDlg, IDC_CI_TABCTRL, TCM_INSERTITEM, 0, reinterpret_cast<LPARAM>(&pop));
-		ws = L"UDL"; pop.cchTextMax = static_cast<int>(ws.size()); pop.pszText = const_cast<LPWSTR>(ws.data());
-		::SendDlgItemMessage(hwndDlg, IDC_CI_TABCTRL, TCM_INSERTITEM, 0, reinterpret_cast<LPARAM>(&pop));
-		::SendDlgItemMessage(hwndDlg, IDC_CI_TABCTRL, TCM_SETCURSEL, 0, 0);
+									wchar_t msg[4096];
+									swprintf_s(msg, L"Command: %s\n\nCode:    %d\nDesc:    [%lld]%s", cmd, errNum, static_cast<INT64>(size), messageBuffer);
+									::MessageBox(NULL, msg, L"Command Error", MB_ICONERROR);
 
-		// disable options
-		HWND hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC);
-		EnableWindow(hwCHK, FALSE);	// ShowWindow(hwCHK, SW_HIDE);
-		hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL);
-		EnableWindow(hwCHK, FALSE);	// ShowWindow(hwCHK, SW_HIDE);
+									LocalFree(messageBuffer);
+								}
 
-		// set progress bar
-		::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 0, 0);
-		Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), L"READY");
-
-		pobjCI = new CollectionInterface(hParent);
-		//pobjCI->getListsFromJson();
-		_populate_file_cbx(hwndDlg, pobjCI->mapUDL, pobjCI->mapDISPLAY);
-
-		// Follow DarkMode
-		::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfInit), reinterpret_cast<LPARAM>(g_hwndCIDlg));
-	}
-
-	return true;
-	case WM_COMMAND:
-		switch (LOWORD(wParam)) {
-		case IDOK:
-		case IDC_CI_BTN_DONE:
-			if (didDownload) {
-				int ans = ::MessageBox(hwndDlg, L"Would you like to restart now?", L"Restart Needed", MB_YESNOCANCEL);
-				switch (ans) {
-				case IDYES:
-				{
-					STARTUPINFOW si;
-					PROCESS_INFORMATION pi;
-
-					ZeroMemory(&si, sizeof(si));
-					si.cb = sizeof(si);
-					ZeroMemory(&pi, sizeof(pi));
-
-					wchar_t cmd[MAX_PATH];
-					swprintf_s(cmd, L"cmd /C ECHO Wait for old Notepad++ to close before launching new copy... & TIMEOUT /T 6 && START \"\" %s", GetCommandLineW());
-					//::MessageBox(NULL, cmd, L"Command to launch:", MB_OK);
-					// If I want to create a persistent console (`cmd /K`), use CREATE_NEW_CONSOLE
-					// if it doesn't need a persistent console (`cmd /C`), use DETACHED_PROCESS
-					//	either one will outlive the parent, so File>Exit will work
-					if (CreateProcessW(nullptr, cmd, nullptr, nullptr, FALSE, CREATE_NEW_CONSOLE, nullptr, nullptr, &si, &pi)) {
-						CloseHandle(pi.hProcess);
-						CloseHandle(pi.hThread);
-
-						HWND hParent = GetParent(hwndDlg);
-						SendMessage(hParent, NPPM_MENUCOMMAND, 0, IDM_FILE_EXIT);
+								break;
+							}
+							case IDNO:
+							{
+								break;
+							}
+							case IDCANCEL:
+							{
+								return true;
+							}
+						}
 					}
-					else {
-						DWORD errNum = GetLastError();
-						LPWSTR messageBuffer = nullptr;
-						size_t size = FormatMessageW(
-							FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-							NULL,
-							errNum,
-							MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-							(LPWSTR)&messageBuffer,
-							0,
-							NULL
-						);
-
-						wchar_t msg[4096];
-						swprintf_s(msg, L"Command: %s\n\nCode:    %d\nDesc:    [%lld]%s", cmd, errNum, static_cast<INT64>(size), messageBuffer);
-						::MessageBox(NULL, msg, L"Command Error", MB_ICONERROR);
-
-						LocalFree(messageBuffer);
-					}
-
-					break;
-				}
-				case IDNO:
-				{
-					break;
-				}
+					// intentionally fall through to IDCANCEL so it exits the dialog
 				case IDCANCEL:
-				{
+					EndDialog(hwndDlg, 0);
+					DestroyWindow(hwndDlg);
+					g_hwndCIDlg = nullptr;
+					delete pobjCI;
+					pobjCI = NULL;
 					return true;
-				}
-				}
-			}
-			// intentionally fall through to IDCANCEL so it exits the dialog
-		case IDCANCEL:
-			EndDialog(hwndDlg, 0);
-			DestroyWindow(hwndDlg);
-			g_hwndCIDlg = nullptr;
-			delete pobjCI;
-			pobjCI = NULL;
-			return true;
-		case IDC_CI_COMBO_FILE:
-			if (HIWORD(wParam) == LBN_SELCHANGE) {
-				LRESULT selectedIndex = ::SendMessage(reinterpret_cast<HWND>(lParam), LB_GETCURSEL, 0, 0);
-				if (selectedIndex != LB_ERR) {
-					LRESULT needLen = ::SendMessage(reinterpret_cast<HWND>(lParam), LB_GETTEXTLEN, selectedIndex, 0);
-					std::wstring wsFilename(needLen, 0);
-					::SendMessage(reinterpret_cast<HWND>(lParam), LB_GETTEXT, selectedIndex, reinterpret_cast<LPARAM>(wsFilename.data()));
-					//::MessageBox(NULL, wsFilename.c_str(), L"Which File:", MB_OK);
+				case IDC_CI_COMBO_FILE:
+					if (HIWORD(wParam) == LBN_SELCHANGE) {
+						LRESULT selectedIndex = ::SendMessage(reinterpret_cast<HWND>(lParam), LB_GETCURSEL, 0, 0);
+						if (selectedIndex != LB_ERR) {
+							LRESULT needLen = ::SendMessage(reinterpret_cast<HWND>(lParam), LB_GETTEXTLEN, selectedIndex, 0);
+							std::wstring wsFilename(needLen, 0);
+							::SendMessage(reinterpret_cast<HWND>(lParam), LB_GETTEXT, selectedIndex, reinterpret_cast<LPARAM>(wsFilename.data()));
+							//::MessageBox(NULL, wsFilename.c_str(), L"Which File:", MB_OK);
 
-					// look at pobjCI->revDISPLAY[]
+							// look at pobjCI->revDISPLAY[]
+							std::wstring ws_id_name = (pobjCI->revDISPLAY.count(wsFilename)) ? pobjCI->revDISPLAY[wsFilename] : L"!!DoesNotExist!!";
+							HWND hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC);
+							EnableWindow(hwCHK, static_cast<BOOL>(pobjCI->mapAC.count(ws_id_name)));
+							hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL);
+							EnableWindow(hwCHK, static_cast<BOOL>(pobjCI->mapFL.count(ws_id_name)));
+
+						}
+						// reset progress bar
+						::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 0, 0);
+						Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), L"READY");
+					}
+					return true;
+				case IDC_CI_BTN_DOWNLOAD:
+				{
+					std::wstring wsCategory = _get_tab_category_wstr(hwndDlg, IDC_CI_TABCTRL);
+					LRESULT selectedFileIndex = ::SendDlgItemMessage(hwndDlg, IDC_CI_COMBO_FILE, LB_GETCURSEL, 0, 0);
+					switch (selectedFileIndex) {
+						case CB_ERR:
+							::MessageBox(NULL, L"Could not understand FILE combobox; sorry", L"Download Error", MB_ICONERROR);
+							return true;
+					}
+
+					LRESULT needFileLen = ::SendDlgItemMessage(hwndDlg, IDC_CI_COMBO_FILE, LB_GETTEXTLEN, selectedFileIndex, 0);
+					std::wstring wsFilename(needFileLen, 0);
+					::SendDlgItemMessage(hwndDlg, IDC_CI_COMBO_FILE, LB_GETTEXT, selectedFileIndex, reinterpret_cast<LPARAM>(wsFilename.data()));
+
+					// update progress bar
+					::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 0, 0);
+					Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), L"Downloading... 0%");
+
+					int total = 1;
 					std::wstring ws_id_name = (pobjCI->revDISPLAY.count(wsFilename)) ? pobjCI->revDISPLAY[wsFilename] : L"!!DoesNotExist!!";
-					HWND hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC);
-					EnableWindow(hwCHK, static_cast<BOOL>(pobjCI->mapAC.count(ws_id_name)));
-					hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL);
-					EnableWindow(hwCHK, static_cast<BOOL>(pobjCI->mapFL.count(ws_id_name)));
+					std::wstring wsURL = L"";
+					std::wstring wsPath = L"";
+					bool isWritable = false;
+					std::map<std::wstring, std::map<std::wstring, std::wstring>> alsoDownload;
+					std::map<std::wstring, bool> extraWritable;
+					if (wsCategory == L"UDL") {
+						if (pobjCI->mapUDL.count(ws_id_name)) {
+							wsURL = pobjCI->mapUDL[ws_id_name];
+						}
 
-				}
-				// reset progress bar
-				::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 0, 0);
-				Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), L"READY");
-			}
-			return true;
-		case IDC_CI_BTN_DOWNLOAD:
-		{
-			std::wstring wsCategory = _get_tab_category_wstr(hwndDlg, IDC_CI_TABCTRL);
-			LRESULT selectedFileIndex = ::SendDlgItemMessage(hwndDlg, IDC_CI_COMBO_FILE, LB_GETCURSEL, 0, 0);
-			switch (selectedFileIndex) {
-			case CB_ERR:
-				::MessageBox(NULL, L"Could not understand FILE combobox; sorry", L"Download Error", MB_ICONERROR);
-				return true;
-			}
+						wsPath = pobjCI->nppCfgUdlDir() + L"\\" + ws_id_name + L".xml";
+						isWritable = pobjCI->isUdlDirWritable();
 
-			LRESULT needFileLen = ::SendDlgItemMessage(hwndDlg, IDC_CI_COMBO_FILE, LB_GETTEXTLEN, selectedFileIndex, 0);
-			std::wstring wsFilename(needFileLen, 0);
-			::SendDlgItemMessage(hwndDlg, IDC_CI_COMBO_FILE, LB_GETTEXT, selectedFileIndex, reinterpret_cast<LPARAM>(wsFilename.data()));
+						// if chkAC, then also download AC
+						bool isCHK = BST_CHECKED == IsDlgButtonChecked(hwndDlg, IDC_CI_CHK_ALSO_AC);
+						bool isEN = IsWindowEnabled(GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC));
+						if (isEN && isCHK && pobjCI->mapAC.count(ws_id_name)) {
+							alsoDownload[L"AC"][L"URL"] = pobjCI->mapAC[ws_id_name];
+							size_t posLastSlash = alsoDownload[L"AC"][L"URL"].rfind(L'/');
+							std::wstring acName = (posLastSlash == std::wstring::npos) ? (ws_id_name + L".xml") : (alsoDownload[L"AC"][L"URL"].substr(posLastSlash + 1));
+							alsoDownload[L"AC"][L"PATH"] = pobjCI->nppCfgAutoCompletionDir() + L"\\" + acName;
+							extraWritable[L"AC"] = pobjCI->isAutoCompletionDirWritable();
+							total++;
+						}
 
-			// update progress bar
-			::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 0, 0);
-			Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), L"Downloading... 0%");
-
-			int total = 1;
-			std::wstring ws_id_name = (pobjCI->revDISPLAY.count(wsFilename)) ? pobjCI->revDISPLAY[wsFilename] : L"!!DoesNotExist!!";
-			std::wstring wsURL = L"";
-			std::wstring wsPath = L"";
-			bool isWritable = false;
-			std::map<std::wstring, std::map<std::wstring, std::wstring>> alsoDownload;
-			std::map<std::wstring, bool> extraWritable;
-			if (wsCategory == L"UDL") {
-				if (pobjCI->mapUDL.count(ws_id_name)) {
-					wsURL = pobjCI->mapUDL[ws_id_name];
-				}
-
-				wsPath = pobjCI->nppCfgUdlDir() + L"\\" + ws_id_name + L".xml";
-				isWritable = pobjCI->isUdlDirWritable();
-
-				// if chkAC, then also download AC
-				bool isCHK = BST_CHECKED == IsDlgButtonChecked(hwndDlg, IDC_CI_CHK_ALSO_AC);
-				bool isEN = IsWindowEnabled(GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC));
-				if (isEN && isCHK && pobjCI->mapAC.count(ws_id_name)) {
-					alsoDownload[L"AC"][L"URL"] = pobjCI->mapAC[ws_id_name];
-					size_t posLastSlash = alsoDownload[L"AC"][L"URL"].rfind(L'/');
-					std::wstring acName = (posLastSlash == std::wstring::npos) ? (ws_id_name + L".xml") : (alsoDownload[L"AC"][L"URL"].substr(posLastSlash+1));
-					alsoDownload[L"AC"][L"PATH"] = pobjCI->nppCfgAutoCompletionDir() + L"\\" + acName;
-					extraWritable[L"AC"] = pobjCI->isAutoCompletionDirWritable();
-					total++;
-				}
-
-				// if cjkFL, then also download FL
-				isCHK = BST_CHECKED == IsDlgButtonChecked(hwndDlg, IDC_CI_CHK_ALSO_FL);
-				isEN = IsWindowEnabled(GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL));
-				if (isEN && isCHK && pobjCI->mapFL.count(ws_id_name)) {
-					alsoDownload[L"FL"][L"URL"] = pobjCI->mapFL[ws_id_name];
-					alsoDownload[L"FL"][L"PATH"] = pobjCI->nppCfgFunctionListDir() + L"\\" + ws_id_name + L".xml";
-					extraWritable[L"FL"] = pobjCI->isFunctionListDirWritable();
-					total++;
-				}
-			}
-			else if (wsCategory == L"AutoCompletion") {
-				size_t posLastSlash = std::wstring::npos;
-				std::wstring acName = ws_id_name + L".xml";
-				if (pobjCI->mapAC.count(ws_id_name)) {
-					wsURL = pobjCI->mapAC[ws_id_name];
-					posLastSlash = wsURL.rfind(L'/');
-					if (posLastSlash != std::wstring::npos) {
-						acName = wsURL.substr(posLastSlash+1);
+						// if cjkFL, then also download FL
+						isCHK = BST_CHECKED == IsDlgButtonChecked(hwndDlg, IDC_CI_CHK_ALSO_FL);
+						isEN = IsWindowEnabled(GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL));
+						if (isEN && isCHK && pobjCI->mapFL.count(ws_id_name)) {
+							alsoDownload[L"FL"][L"URL"] = pobjCI->mapFL[ws_id_name];
+							alsoDownload[L"FL"][L"PATH"] = pobjCI->nppCfgFunctionListDir() + L"\\" + ws_id_name + L".xml";
+							extraWritable[L"FL"] = pobjCI->isFunctionListDirWritable();
+							total++;
+						}
 					}
-				}
+					else if (wsCategory == L"AutoCompletion") {
+						size_t posLastSlash = std::wstring::npos;
+						std::wstring acName = ws_id_name + L".xml";
+						if (pobjCI->mapAC.count(ws_id_name)) {
+							wsURL = pobjCI->mapAC[ws_id_name];
+							posLastSlash = wsURL.rfind(L'/');
+							if (posLastSlash != std::wstring::npos) {
+								acName = wsURL.substr(posLastSlash + 1);
+							}
+						}
 
-				wsPath = pobjCI->nppCfgAutoCompletionDir() + L"\\" + acName;
-				isWritable = pobjCI->isAutoCompletionDirWritable();
-			}
-			else if (wsCategory == L"FunctionList") {
-				if (pobjCI->mapFL.count(ws_id_name)) {
-					wsURL = pobjCI->mapFL[ws_id_name];
-				}
+						wsPath = pobjCI->nppCfgAutoCompletionDir() + L"\\" + acName;
+						isWritable = pobjCI->isAutoCompletionDirWritable();
+					}
+					else if (wsCategory == L"FunctionList") {
+						if (pobjCI->mapFL.count(ws_id_name)) {
+							wsURL = pobjCI->mapFL[ws_id_name];
+						}
 
-				wsPath = pobjCI->nppCfgFunctionListDir() + L"\\" + ws_id_name + L".xml";
-				isWritable = pobjCI->isFunctionListDirWritable();
-			}
-			else if (wsCategory == L"Theme") {
-				wsURL = L"https://raw.githubusercontent.com/notepad-plus-plus/nppThemes/main/themes/" + wsFilename;
+						wsPath = pobjCI->nppCfgFunctionListDir() + L"\\" + ws_id_name + L".xml";
+						isWritable = pobjCI->isFunctionListDirWritable();
+					}
+					else if (wsCategory == L"Theme") {
+						wsURL = L"https://raw.githubusercontent.com/notepad-plus-plus/nppThemes/main/themes/" + wsFilename;
 
-				wsPath = pobjCI->nppCfgThemesDir() + L"\\" + wsFilename;
-				isWritable = pobjCI->isThemesDirWritable();
-			}
+						wsPath = pobjCI->nppCfgThemesDir() + L"\\" + wsFilename;
+						isWritable = pobjCI->isThemesDirWritable();
+					}
 
-			int count = 0;
-			if (isWritable) {
-				// download directly to the final destination
-				didDownload |= pobjCI->downloadFileToDisk(wsURL, wsPath);
-				std::wstring msg = L"Downloaded to " + wsPath;
-				//::MessageBox(hwndDlg, msg.c_str(), L"Download Successful", MB_OK);
-				count++;
-			}
-			else {
-				// check if it needs to be overwritten before elevating permissions
-				if (pobjCI->ask_overwrite_if_exists(wsPath)) {
-					// download to a temp path, then use ShellExecute(runas) to move it from the temp path to the final destination
-					std::wstring wsAsk = L"Cannot write to " + wsPath;
-					wsAsk += L"\nI will try again with elevated UAC permission.";
-					int ans = ::MessageBox(hwndDlg, wsAsk.c_str(), L"Need Directory Permission", MB_OKCANCEL);
-					if (ans == IDOK) {
-						std::wstring tmpPath = pobjCI->getWritableTempDir() + L"\\~$TMPFILE.DOWNLOAD.PRYRT.xml";
-						pobjCI->downloadFileToDisk(wsURL, tmpPath);
-						std::wstring msg = L"Downloaded from\n" + tmpPath + L"\nand moved to\n" + wsPath;
-						std::wstring args = L"/C MOVE /Y \"" + tmpPath + L"\" \"" + wsPath + L"\"";
-						ShellExecute(hwndDlg, L"runas", L"cmd.exe", args.c_str(), NULL, SW_SHOWMINIMIZED);
-						//::MessageBox(hwndDlg, msg.c_str(), L"Download and UAC move", MB_OK);
+					int count = 0;
+					if (isWritable) {
+						// download directly to the final destination
+						didDownload |= pobjCI->downloadFileToDisk(wsURL, wsPath);
+						std::wstring msg = L"Downloaded to " + wsPath;
+						//::MessageBox(hwndDlg, msg.c_str(), L"Download Successful", MB_OK);
 						count++;
-						didDownload = true;
 					}
 					else {
-						total--;
-					}
-				}
-				else {
-					total--;
-				}
-			}
-
-			// update progress bar
-			::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 100 * count / total, 0);
-			wchar_t wcDLPCT[256];
-			swprintf_s(wcDLPCT, L"Downloading %d%%", 100 * count / total);
-			Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), wcDLPCT);
-
-			// also download AC and FL, if applicable
-			std::vector<std::wstring> xtra = { L"AC", L"FL" };
-			for (auto category : xtra) {
-				if (alsoDownload.count(category)) {
-					std::wstring xURL = alsoDownload[category][L"URL"];
-					std::wstring xPath = alsoDownload[category][L"PATH"];
-					if (extraWritable[category]) {
-						pobjCI->downloadFileToDisk(xURL, xPath);
-						count++;
-						didDownload = true;
-					}
-					else {
-						if (pobjCI->ask_overwrite_if_exists(xPath)) {
+						// check if it needs to be overwritten before elevating permissions
+						if (pobjCI->ask_overwrite_if_exists(wsPath)) {
 							// download to a temp path, then use ShellExecute(runas) to move it from the temp path to the final destination
-							std::wstring wsAsk = L"Cannot write to " + xPath;
+							std::wstring wsAsk = L"Cannot write to " + wsPath;
 							wsAsk += L"\nI will try again with elevated UAC permission.";
 							int ans = ::MessageBox(hwndDlg, wsAsk.c_str(), L"Need Directory Permission", MB_OKCANCEL);
 							if (ans == IDOK) {
 								std::wstring tmpPath = pobjCI->getWritableTempDir() + L"\\~$TMPFILE.DOWNLOAD.PRYRT.xml";
-								pobjCI->downloadFileToDisk(xURL, tmpPath);
-								std::wstring msg = L"Downloaded from\n" + tmpPath + L"\nand moved to\n" + xPath;
-								std::wstring args = L"/C MOVE /Y \"" + tmpPath + L"\" \"" + xPath + L"\"";
+								pobjCI->downloadFileToDisk(wsURL, tmpPath);
+								std::wstring msg = L"Downloaded from\n" + tmpPath + L"\nand moved to\n" + wsPath;
+								std::wstring args = L"/C MOVE /Y \"" + tmpPath + L"\" \"" + wsPath + L"\"";
 								ShellExecute(hwndDlg, L"runas", L"cmd.exe", args.c_str(), NULL, SW_SHOWMINIMIZED);
+								//::MessageBox(hwndDlg, msg.c_str(), L"Download and UAC move", MB_OK);
 								count++;
 								didDownload = true;
 							}
@@ -361,153 +338,120 @@ INT_PTR CALLBACK ciDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam
 							total--;
 						}
 					}
+
+					// update progress bar
+					::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 100 * count / total, 0);
+					wchar_t wcDLPCT[256];
+					swprintf_s(wcDLPCT, L"Downloading %d%%", 100 * count / total);
+					Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), wcDLPCT);
+
+					// also download AC and FL, if applicable
+					std::vector<std::wstring> xtra = { L"AC", L"FL" };
+					for (auto category : xtra) {
+						if (alsoDownload.count(category)) {
+							std::wstring xURL = alsoDownload[category][L"URL"];
+							std::wstring xPath = alsoDownload[category][L"PATH"];
+							if (extraWritable[category]) {
+								pobjCI->downloadFileToDisk(xURL, xPath);
+								count++;
+								didDownload = true;
+							}
+							else {
+								if (pobjCI->ask_overwrite_if_exists(xPath)) {
+									// download to a temp path, then use ShellExecute(runas) to move it from the temp path to the final destination
+									std::wstring wsAsk = L"Cannot write to " + xPath;
+									wsAsk += L"\nI will try again with elevated UAC permission.";
+									int ans = ::MessageBox(hwndDlg, wsAsk.c_str(), L"Need Directory Permission", MB_OKCANCEL);
+									if (ans == IDOK) {
+										std::wstring tmpPath = pobjCI->getWritableTempDir() + L"\\~$TMPFILE.DOWNLOAD.PRYRT.xml";
+										pobjCI->downloadFileToDisk(xURL, tmpPath);
+										std::wstring msg = L"Downloaded from\n" + tmpPath + L"\nand moved to\n" + xPath;
+										std::wstring args = L"/C MOVE /Y \"" + tmpPath + L"\" \"" + xPath + L"\"";
+										ShellExecute(hwndDlg, L"runas", L"cmd.exe", args.c_str(), NULL, SW_SHOWMINIMIZED);
+										count++;
+										didDownload = true;
+									}
+									else {
+										total--;
+									}
+								}
+								else {
+									total--;
+								}
+							}
+						}
+						// update progress bar
+						::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 100 * count / total, 0);
+						swprintf_s(wcDLPCT, L"Downloading %d%%", 100 * count / total);
+						Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), wcDLPCT);
+					}
+
+					// Final update of progress bar: 100%
+					::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 100, 0);
+					swprintf_s(wcDLPCT, L"Downloading %d%% [DONE]", 100);
+					Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), wcDLPCT);
 				}
-				// update progress bar
-				::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 100 * count / total, 0);
-				swprintf_s(wcDLPCT, L"Downloading %d%%", 100 * count / total);
-				Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), wcDLPCT);
+				return true;
+				case IDC_CI_HELPBTN:
+				{
+					showCIDownloadHelp();
+				}
+				return true;
+				default:
+					return false;
 			}
-
-			// Final update of progress bar: 100%
-			::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 100, 0);
-			swprintf_s(wcDLPCT, L"Downloading %d%% [DONE]", 100);
-			Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), wcDLPCT);
-		}
-		return true;
-		case IDC_CI_HELPBTN:
+		case WM_NOTIFY:
 		{
-			showCIDownloadHelp();
-		}
-		return true;
-		default:
+			if ((wParam == IDC_CI_TABCTRL) && (((LPNMHDR)lParam)->code == TCN_SELCHANGE)) {
+				std::wstring wsCategory = _get_tab_category_wstr(hwndDlg, IDC_CI_TABCTRL);
+				if (wsCategory == L"UDL") {
+					_populate_file_cbx(hwndDlg, pobjCI->mapUDL, pobjCI->mapDISPLAY);
+					// disable options
+					HWND hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC);
+					EnableWindow(hwCHK, FALSE);
+					ShowWindow(hwCHK, SW_SHOW);
+					hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL);
+					EnableWindow(hwCHK, FALSE);
+					ShowWindow(hwCHK, SW_SHOW);
+				}
+				else if (wsCategory == L"AutoCompletion") {
+					_populate_file_cbx(hwndDlg, pobjCI->mapAC, pobjCI->mapDISPLAY);
+					// disable options
+					HWND hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC);
+					ShowWindow(hwCHK, SW_HIDE);
+					hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL);
+					ShowWindow(hwCHK, SW_HIDE);
+				}
+				else if (wsCategory == L"FunctionList") {
+					_populate_file_cbx(hwndDlg, pobjCI->mapFL, pobjCI->mapDISPLAY);
+					// disable options
+					HWND hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC);
+					ShowWindow(hwCHK, SW_HIDE);
+					hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL);
+					ShowWindow(hwCHK, SW_HIDE);
+				}
+				else if (wsCategory == L"Theme") {
+					_populate_file_cbx(hwndDlg, pobjCI->vThemeFiles);
+					// disable options
+					HWND hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC);
+					ShowWindow(hwCHK, SW_HIDE);
+					hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL);
+					ShowWindow(hwCHK, SW_HIDE);
+				}
+				// reset progress bar
+				::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 0, 0);
+				Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), L"READY");
+
+				// done with SELCHANGE
+				return true;
+			}
 			return false;
 		}
-	case WM_NOTIFY:
-	{
-		if ((wParam == IDC_CI_TABCTRL) && (((LPNMHDR)lParam)->code == TCN_SELCHANGE)) {
-			std::wstring wsCategory = _get_tab_category_wstr(hwndDlg, IDC_CI_TABCTRL);
-			if (wsCategory == L"UDL") {
-				_populate_file_cbx(hwndDlg, pobjCI->mapUDL, pobjCI->mapDISPLAY);
-				// disable options
-				HWND hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC);
-				EnableWindow(hwCHK, FALSE);
-				ShowWindow(hwCHK, SW_SHOW);
-				hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL);
-				EnableWindow(hwCHK, FALSE);
-				ShowWindow(hwCHK, SW_SHOW);
-			}
-			else if (wsCategory == L"AutoCompletion") {
-				_populate_file_cbx(hwndDlg, pobjCI->mapAC, pobjCI->mapDISPLAY);
-				// disable options
-				HWND hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC);
-				ShowWindow(hwCHK, SW_HIDE);
-				hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL);
-				ShowWindow(hwCHK, SW_HIDE);
-			}
-			else if (wsCategory == L"FunctionList") {
-				_populate_file_cbx(hwndDlg, pobjCI->mapFL, pobjCI->mapDISPLAY);
-				// disable options
-				HWND hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC);
-				ShowWindow(hwCHK, SW_HIDE);
-				hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL);
-				ShowWindow(hwCHK, SW_HIDE);
-			}
-			else if (wsCategory == L"Theme") {
-				_populate_file_cbx(hwndDlg, pobjCI->vThemeFiles);
-				// disable options
-				HWND hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_AC);
-				ShowWindow(hwCHK, SW_HIDE);
-				hwCHK = GetDlgItem(hwndDlg, IDC_CI_CHK_ALSO_FL);
-				ShowWindow(hwCHK, SW_HIDE);
-			}
-			// reset progress bar
-			::SendDlgItemMessage(hwndDlg, IDC_CI_PROGRESSBAR, PBM_SETPOS, 0, 0);
-			Edit_SetText(GetDlgItem(hwndDlg, IDC_CI_PROGRESSLBL), L"READY");
-
-			// done with SELCHANGE
+		case WM_DESTROY:
+			DestroyWindow(hwndTab);
+			DestroyWindow(hwndDlg);
+			g_hwndCIDlg = nullptr;
 			return true;
-		}
-	}
-	return false;
-	case WM_CTLCOLORBTN: // fallthru
-	case WM_CTLCOLOREDIT: // fallthru
-	case WM_CTLCOLORDLG: // fallthru
-	case WM_CTLCOLORLISTBOX: // fallthru
-	case WM_CTLCOLORSCROLLBAR: // fallthru
-	case WM_CTLCOLORSTATIC: // fallthru
-	case WM_CTLCOLOR: {
-		int id = GetDlgCtrlID((HWND)lParam);
-		switch (id) {
-		case IDC_CI_TABCTRL: {
-			HDC hdc = (HDC)wParam;
-			SetBkColor(hdc, RGB(255, 0, 0));
-			break;
-		}
-		case IDC_CI_BTN_DOWNLOAD:
-			return false;
-		case IDC_CI_BTN_DONE:
-			return false;
-		case IDC_CI_COMBO_FILE:
-			return false;
-		case IDC_CI_PROGRESSBAR:
-			return false;
-		case IDC_CI_CHK_ALSO_FL:
-			return false;
-		case IDC_CI_CHK_ALSO_AC:
-			return false;
-		case IDC_CI_HELPBTN:
-			return false;
-		case IDC_CI_PROGRESSLBL:
-			return false;
-		default:
-			return false;
-		}
-		return (LRESULT)hBgBrush;
-	}
-	case WM_DRAWITEM: {
-		LPDRAWITEMSTRUCT lpDrawItem = (LPDRAWITEMSTRUCT)lParam;
-		int id = GetDlgCtrlID(lpDrawItem->hwndItem);
-		if (id == IDC_CI_TABCTRL) {
-			if (lpDrawItem->CtlType != ODT_TAB)		// https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-drawitemstruct
-				return false;
-
-
-			// cf: https://www.google.com/search?q=win32+api+c%2B%2B+%22SysTabControl32%22+dark+mode&rlz=1C1QCTP_enUS1147US1147&oq=win32+api+c%2B%2B+%22SysTabControl32%22+dark+mode&gs_lcrp=EgZjaHJvbWUyBggAEEUYOTIHCAEQIRigATIHCAIQIRigATIHCAMQIRigATIHCAQQIRirAtIBCDcwMDdqMGo3qAIAsAIA&sourceid=chrome&ie=UTF-8
-			HDC hdc = lpDrawItem->hDC;
-			RECT rc = lpDrawItem->rcItem;
-			int tabIndex = lpDrawItem->itemID;
-
-			// Draw background
-			//HBRUSH hBrush = CreateSolidBrush(bgColor);
-			//FillRect(hdc, &rc, hBrush);
-			//DeleteObject(hBrush);
-
-			// Draw text
-			SetTextColor(hdc, rgbTextFG);
-			//SetBkMode(hdc, TRANSPARENT);
-			SetBkColor(hdc, rgbTextBG);
-			TCHAR text[256];
-			TCITEM tcItem;
-			tcItem.mask = TCIF_TEXT;
-			tcItem.pszText = text;
-			tcItem.cchTextMax = 256;
-			TabCtrl_GetItem(lpDrawItem->hwndItem, tabIndex, &tcItem);
-			DrawText(hdc, text, -1, &rc, DT_CENTER | DT_SINGLELINE | DT_VCENTER);
-
-			//COLORREF customBackColor = RGB(255, 0, 0); // Red background
-			//HBRUSH hBrush = CreateSolidBrush(customBackColor);
-			//FillRect(lpDrawItem->hDC, &lpDrawItem->rcItem, hBrush);
-			//DeleteObject(hBrush);
-			return (LRESULT)hBgBrush;
-		}
-		return false;
-	}
-	case WM_DESTROY:
-		DestroyWindow(hwndDlg);
-		g_hwndCIDlg = nullptr;
-		DeleteObject(hBgBrush);
-		hBgBrush = nullptr;
-		return true;
 	}
 	return false;
 }
@@ -569,82 +513,226 @@ INT_PTR CALLBACK cidlHelpDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 	}
 
 	switch (uMsg) {
-	case WM_INITDIALOG:
-	{
-		// Find Center and then position the window:
-
-		// find App center
-		RECT rc;
-		HWND hParent = GetParent(hwndDlg);
-		::GetClientRect(hParent, &rc);
-		POINT center;
-		int w = rc.right - rc.left;
-		int h = rc.bottom - rc.top;
-		center.x = rc.left + w / 2;
-		center.y = rc.top + h / 2;
-		::ClientToScreen(hParent, &center);
-		rc.left -= static_cast<int>(lParam);
-		rc.left -= static_cast<int>(wParam);
-		rc.left += static_cast<int>(lParam);
-		rc.left += static_cast<int>(wParam);
-
-		// and position dialog
-		RECT dlgRect;
-		::GetClientRect(hwndDlg, &dlgRect);
-		int x = center.x - (dlgRect.right - dlgRect.left) / 2;
-		int y = center.y - (dlgRect.bottom - dlgRect.top) / 2;
-		::SetWindowPos(hwndDlg, HWND_TOP, x, y, (dlgRect.right - dlgRect.left), (dlgRect.bottom - dlgRect.top), SWP_SHOWWINDOW);
-
-		// populate with help text:
-		HWND hEdit = ::GetDlgItem(hwndDlg, IDC_CIDH_BIGTEXT);
-		::SetWindowText(hEdit, wsHelpText.c_str());
-		//::SendMessage(hEdit, EM_SETREADONLY, static_cast<WPARAM>(false), 0);
-		//::SendMessage(hEdit, WM_CLEAR, 0, 0);
-		//::SendMessage(hEdit, EM_SETSEL, static_cast<WPARAM>(-1), static_cast<LPARAM>(-1));
-		//::SendMessage(hEdit, EM_SETREADONLY, static_cast<WPARAM>(true), 0);
-		//::SendMessage(hwndDlg, WM_SIZE, static_cast<WPARAM>(dlgRect.right - dlgRect.left), static_cast<LPARAM>(dlgRect.bottom - dlgRect.top));
-
-	}
-
-	return true;
-	case WM_COMMAND:
-		switch (LOWORD(wParam))
+		case WM_INITDIALOG:
 		{
-		case IDCANCEL:
-		case IDOK:
+			// Find Center and then position the window:
+
+			// find App center
+			RECT rc;
+			HWND hParent = GetParent(hwndDlg);
+			::GetClientRect(hParent, &rc);
+			POINT center;
+			int w = rc.right - rc.left;
+			int h = rc.bottom - rc.top;
+			center.x = rc.left + w / 2;
+			center.y = rc.top + h / 2;
+			::ClientToScreen(hParent, &center);
+			rc.left -= static_cast<int>(lParam);
+			rc.left -= static_cast<int>(wParam);
+			rc.left += static_cast<int>(lParam);
+			rc.left += static_cast<int>(wParam);
+
+			// and position dialog
+			RECT dlgRect;
+			::GetClientRect(hwndDlg, &dlgRect);
+			int x = center.x - (dlgRect.right - dlgRect.left) / 2;
+			int y = center.y - (dlgRect.bottom - dlgRect.top) / 2;
+			::SetWindowPos(hwndDlg, HWND_TOP, x, y, (dlgRect.right - dlgRect.left), (dlgRect.bottom - dlgRect.top), SWP_SHOWWINDOW);
+
+			// populate with help text:
+			HWND hEdit = ::GetDlgItem(hwndDlg, IDC_CIDH_BIGTEXT);
+			::SetWindowText(hEdit, wsHelpText.c_str());
+			//::SendMessage(hEdit, EM_SETREADONLY, static_cast<WPARAM>(false), 0);
+			//::SendMessage(hEdit, WM_CLEAR, 0, 0);
+			//::SendMessage(hEdit, EM_SETSEL, static_cast<WPARAM>(-1), static_cast<LPARAM>(-1));
+			//::SendMessage(hEdit, EM_SETREADONLY, static_cast<WPARAM>(true), 0);
+			//::SendMessage(hwndDlg, WM_SIZE, static_cast<WPARAM>(dlgRect.right - dlgRect.left), static_cast<LPARAM>(dlgRect.bottom - dlgRect.top));
+
+		}
+
+		return true;
+		case WM_COMMAND:
+			switch (LOWORD(wParam))
+			{
+				case IDCANCEL:
+				case IDOK:
+					EndDialog(hwndDlg, 0);
+					DestroyWindow(hwndDlg);
+					return true;
+			}
+			return false;
+		case WM_CLOSE:
 			EndDialog(hwndDlg, 0);
 			DestroyWindow(hwndDlg);
 			return true;
+		case WM_SIZE:
+		{
+			//// int newWidth = LOWORD(lParam);
+			//// int newHeight = HIWORD(lParam);
+			//// 
+			//// // Resize the edit control, adjust position and size as needed
+			//// HWND hEdit = ::GetDlgItem(hwndDlg, IDC_CIDH_BIGTEXT);
+			//// SetWindowPos(
+			//// 	hEdit,
+			//// 	nullptr,
+			//// 	10, // X position
+			//// 	10, // Y position
+			//// 	newWidth - 20, // Width
+			//// 	newHeight - 20, // Height
+			//// 	SWP_NOZORDER
+			//// );
+			//// //::SendMessage(hEdit, EM_SETREADONLY, static_cast<WPARAM>(false), 0);
+			//// //::SetWindowText(hEdit, L"Hello World");
+			//// //::SendMessage(hEdit, EM_SETSEL, 0, 0);
+			//// ::SetWindowText(hEdit, wsHelpText.c_str());
+			//// //::SendMessage(hEdit, EM_SETREADONLY, static_cast<WPARAM>(true), 0);
+			return true;
 		}
-		return false;
-	case WM_CLOSE:
-		EndDialog(hwndDlg, 0);
-		DestroyWindow(hwndDlg);
-		return true;
-	case WM_SIZE:
+		default:
+			return false;
+	}
+}
+
+static LRESULT CALLBACK cbTabSubclass(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR /*dwRefData*/)
+{
+	if (!g_IsDarkMode) return false;
+	switch (uMsg)
 	{
-		//// int newWidth = LOWORD(lParam);
-		//// int newHeight = HIWORD(lParam);
-		//// 
-		//// // Resize the edit control, adjust position and size as needed
-		//// HWND hEdit = ::GetDlgItem(hwndDlg, IDC_CIDH_BIGTEXT);
-		//// SetWindowPos(
-		//// 	hEdit,
-		//// 	nullptr,
-		//// 	10, // X position
-		//// 	10, // Y position
-		//// 	newWidth - 20, // Width
-		//// 	newHeight - 20, // Height
-		//// 	SWP_NOZORDER
-		//// );
-		//// //::SendMessage(hEdit, EM_SETREADONLY, static_cast<WPARAM>(false), 0);
-		//// //::SetWindowText(hEdit, L"Hello World");
-		//// //::SendMessage(hEdit, EM_SETSEL, 0, 0);
-		//// ::SetWindowText(hEdit, wsHelpText.c_str());
-		//// //::SendMessage(hEdit, EM_SETREADONLY, static_cast<WPARAM>(true), 0);
-		return true;
+		case WM_ERASEBKGND:
+		{
+			return TRUE;
+		}
+
+		case WM_PAINT:
+		{
+			LONG_PTR dwStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+			if ((dwStyle & TCS_BUTTONS) || (dwStyle & TCS_VERTICAL))
+			{
+				break;
+			}
+
+			PAINTSTRUCT ps{};
+			HDC hdc = ::BeginPaint(hWnd, &ps);
+			::FillRect(hdc, &ps.rcPaint, myBrushes.dlgBackground);
+
+			auto holdPen = static_cast<HPEN>(::SelectObject(hdc, myPens.edgePen));
+
+			HRGN holdClip = CreateRectRgn(0, 0, 0, 0);
+			if (1 != GetClipRgn(hdc, holdClip))
+			{
+				DeleteObject(holdClip);
+				holdClip = nullptr;
+			}
+
+			HFONT hFont = reinterpret_cast<HFONT>(SendMessage(hWnd, WM_GETFONT, 0, 0));
+			auto hOldFont = SelectObject(hdc, hFont);
+
+			POINT ptCursor{};
+			::GetCursorPos(&ptCursor);
+			ScreenToClient(hWnd, &ptCursor);
+
+			int nTabs = TabCtrl_GetItemCount(hWnd);
+
+			int nSelTab = TabCtrl_GetCurSel(hWnd);
+			for (int i = 0; i < nTabs; ++i)
+			{
+				RECT rcItem{};
+				TabCtrl_GetItemRect(hWnd, i, &rcItem);
+				RECT rcFrame = rcItem;
+
+				RECT rcIntersect{};
+				if (IntersectRect(&rcIntersect, &ps.rcPaint, &rcItem))
+				{
+					bool bHot = PtInRect(&rcItem, ptCursor);
+					bool isSelectedTab = (i == nSelTab);
+
+					HRGN hClip = CreateRectRgnIndirect(&rcItem);
+
+					SelectClipRgn(hdc, hClip);
+
+					SetTextColor(hdc, (bHot || isSelectedTab) ? myColors.text : myColors.darkerText);
+
+					::InflateRect(&rcItem, -1, -1);
+					rcItem.right += 1;
+
+					// for consistency getBackgroundBrush()
+					// would be better, than getCtrlBackgroundBrush(),
+					// however default getBackgroundBrush() has same color
+					// as getDlgBackgroundBrush()
+					::FillRect(hdc, &rcItem, isSelectedTab ? myBrushes.dlgBackground : bHot ? myBrushes.hotBackground : myBrushes.ctrlBackground);
+
+					SetBkMode(hdc, TRANSPARENT);
+
+					wchar_t label[MAX_PATH]{};
+					TCITEM tci{};
+					tci.mask = TCIF_TEXT;
+					tci.pszText = label;
+					tci.cchTextMax = MAX_PATH - 1;
+
+					::SendMessage(hWnd, TCM_GETITEM, i, reinterpret_cast<LPARAM>(&tci));
+
+					RECT rcText = rcItem;
+					if (isSelectedTab)
+					{
+						::OffsetRect(&rcText, 0, -1);
+						::InflateRect(&rcFrame, 0, 1);
+					}
+
+					if (i != nTabs - 1)
+					{
+						rcFrame.right += 1;
+					}
+
+					::FrameRect(hdc, &rcFrame, myBrushes.edgeBrush);
+
+					DrawText(hdc, label, -1, &rcText, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+
+					DeleteObject(hClip);
+
+					SelectClipRgn(hdc, holdClip);
+				}
+			}
+
+			SelectObject(hdc, hOldFont);
+
+			SelectClipRgn(hdc, holdClip);
+			if (holdClip)
+			{
+				DeleteObject(holdClip);
+				holdClip = nullptr;
+			}
+
+			SelectObject(hdc, holdPen);
+
+			EndPaint(hWnd, &ps);
+			return 0;
+		}
+
+		case WM_NCDESTROY:
+		{
+			::RemoveWindowSubclass(hWnd, cbTabSubclass, uIdSubclass);
+			break;
+		}
+
+#if 0
+		case WM_PARENTNOTIFY:
+		{
+			switch (LOWORD(wParam))
+			{
+				case WM_CREATE:
+				{
+					auto hwndUpdown = reinterpret_cast<HWND>(lParam);
+					if (subclassTabUpDownControl(hwndUpdown))
+					{
+						return 0;
+					}
+					break;
+				}
+			}
+			return 0;
+		}
+#endif
+
 	}
-	default:
-		return false;
-	}
+	return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }

--- a/src/Dialogs/CollectionInterfaceDialog.cpp
+++ b/src/Dialogs/CollectionInterfaceDialog.cpp
@@ -29,7 +29,7 @@
 #include <CommCtrl.h>
 
 
-HWND g_hwndCIDlg = nullptr;
+HWND g_hwndCIDlg = nullptr, g_hwndCIHlpDlg = nullptr;
 CollectionInterface* pobjCI;
 void _populate_file_cbx(HWND hwndDlg, std::vector<std::wstring>& vsList);
 void _populate_file_cbx(HWND hwndDlg, std::map<std::wstring, std::wstring>& mapURLs, std::map<std::wstring, std::wstring>& mapDisplay);
@@ -507,6 +507,15 @@ INT_PTR CALLBACK cidlHelpDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 	switch (uMsg) {
 		case WM_INITDIALOG:
 		{
+			// store hwnd
+			g_hwndCIHlpDlg = hwndDlg;
+
+			// determine dark mode
+			g_IsDarkMode = (bool)::SendMessage(nppData._nppHandle, NPPM_ISDARKMODEENABLED, 0, 0);
+			if (g_IsDarkMode) {
+				::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfInit), reinterpret_cast<LPARAM>(g_hwndCIHlpDlg));
+			}
+
 			// Find Center and then position the window:
 
 			// find App center
@@ -705,6 +714,7 @@ static LRESULT CALLBACK cbTabSubclass(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			::RemoveWindowSubclass(hWnd, cbTabSubclass, uIdSubclass);
 			break;
 		}
+
 	}
 	return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }

--- a/src/Dialogs/CollectionInterfaceDialog.cpp
+++ b/src/Dialogs/CollectionInterfaceDialog.cpp
@@ -702,31 +702,9 @@ static LRESULT CALLBACK cbTabSubclass(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 		case WM_NCDESTROY:
 		{
-			// try not removing the sublcass: //
 			::RemoveWindowSubclass(hWnd, cbTabSubclass, uIdSubclass);
-			//g_ci_dark_subclass = uIdSubclass + 1;	// try moving to next subclass number each time through
 			break;
 		}
-
-#if 0
-		case WM_PARENTNOTIFY:
-		{
-			switch (LOWORD(wParam))
-			{
-				case WM_CREATE:
-				{
-					auto hwndUpdown = reinterpret_cast<HWND>(lParam);
-					if (subclassTabUpDownControl(hwndUpdown))
-					{
-						return 0;
-					}
-					break;
-				}
-			}
-			return 0;
-		}
-#endif
-
 	}
 	return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }

--- a/src/Dialogs/CollectionInterfaceDialog.rc
+++ b/src/Dialogs/CollectionInterfaceDialog.rc
@@ -31,7 +31,7 @@ CAPTION "Collection Interface: Download"
 FONT 8, "MS Shell Dlg", 0, 0, 0x1
 BEGIN
     LTEXT           "Download files from UDL Collection or Themes Collection", IDC_STATIC, 10, 5, 280, 9, SS_LEFT, WS_EX_LEFT
-    CONTROL         "",IDC_CI_TABCTRL,"SysTabControl32",0x0,10,17,280,148
+    CONTROL         "",IDC_CI_TABCTRL,"SysTabControl32",0x0 | TCS_OWNERDRAWFIXED,10,17,280,148
     LISTBOX         IDC_CI_COMBO_FILE, 13, 32, 272, 120, CBS_DROPDOWNLIST | CBS_AUTOHSCROLL | CBS_DISABLENOSCROLL | WS_VSCROLL | WS_TABSTOP
     CHECKBOX        "Also AutoCompletion", IDC_CI_CHK_ALSO_AC, 13, 140, 100, 11, WS_VISIBLE | WS_CHILD | BS_AUTOCHECKBOX
     CHECKBOX        "Also FunctionList", IDC_CI_CHK_ALSO_FL, 13, 151, 100, 11, WS_VISIBLE | WS_CHILD | BS_AUTOCHECKBOX

--- a/src/Dialogs/CollectionInterfaceDialog.rc
+++ b/src/Dialogs/CollectionInterfaceDialog.rc
@@ -31,7 +31,7 @@ CAPTION "Collection Interface: Download"
 FONT 8, "MS Shell Dlg", 0, 0, 0x1
 BEGIN
     LTEXT           "Download files from UDL Collection or Themes Collection", IDC_STATIC, 10, 5, 280, 9, SS_LEFT, WS_EX_LEFT
-    CONTROL         "",IDC_CI_TABCTRL,"SysTabControl32",0x0 | TCS_OWNERDRAWFIXED,10,17,280,148
+    CONTROL         "",IDC_CI_TABCTRL,"SysTabControl32",0x0,10,17,280,148
     LISTBOX         IDC_CI_COMBO_FILE, 13, 32, 272, 120, CBS_DROPDOWNLIST | CBS_AUTOHSCROLL | CBS_DISABLENOSCROLL | WS_VSCROLL | WS_TABSTOP
     CHECKBOX        "Also AutoCompletion", IDC_CI_CHK_ALSO_AC, 13, 140, 100, 11, WS_VISIBLE | WS_CHILD | BS_AUTOCHECKBOX
     CHECKBOX        "Also FunctionList", IDC_CI_CHK_ALSO_FL, 13, 151, 100, 11, WS_VISIBLE | WS_CHILD | BS_AUTOCHECKBOX

--- a/src/Hyperlinks.cpp
+++ b/src/Hyperlinks.cpp
@@ -16,6 +16,9 @@
 #define PROP_STATIC_HYPERLINK	TEXT("_Hyperlink_From_Static_")
 #define PROP_UNDERLINE_FONT		TEXT("_Hyperlink_Underline_Font_")
 
+// CollectionInterface wants to be able to change the color of the hyperlink, but default to URL-blue
+COLORREF _hyperlink_rgb = RGB(0, 0, 192);
+COLORREF SetHyperlinkRGB(COLORREF rgbNew) { _hyperlink_rgb = rgbNew; return _hyperlink_rgb; }
 
 LRESULT CALLBACK _HyperlinkParentProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
@@ -32,7 +35,7 @@ LRESULT CALLBACK _HyperlinkParentProc(HWND hwnd, UINT message, WPARAM wParam, LP
 		if (fHyperlink)
 		{
 			LRESULT lr = CallWindowProc(pfnOrigProc, hwnd, message, wParam, lParam);
-			SetTextColor(hdc, RGB(0, 0, 192));
+			SetTextColor(hdc, _hyperlink_rgb);	// CollectionInterface plugin: changed this to configurable
 			return lr;
 		}
 

--- a/src/Hyperlinks.h
+++ b/src/Hyperlinks.h
@@ -11,5 +11,6 @@
 
 BOOL ConvertStaticToHyperlink(HWND hwndCtl);
 BOOL ConvertStaticToHyperlink(HWND hwndParent, UINT uiCtlId);
+COLORREF SetHyperlinkRGB(COLORREF rgbNew);	// added by ConfigUpdater plugin
 
 #endif

--- a/src/NPP_DarkMode.h
+++ b/src/NPP_DarkMode.h
@@ -36,4 +36,105 @@ namespace NppDarkMode {
 		COLORREF hotEdge = 0;
 		COLORREF disabledEdge = 0;
 	};
+
+	struct Brushes
+	{
+		HBRUSH background = nullptr;
+		HBRUSH ctrlBackground = nullptr;
+		HBRUSH hotBackground = nullptr;
+		HBRUSH dlgBackground = nullptr;
+		HBRUSH errorBackground = nullptr;
+
+		HBRUSH edgeBrush = nullptr;
+		HBRUSH hotEdgeBrush = nullptr;
+		HBRUSH disabledEdgeBrush = nullptr;
+
+		Brushes(const Colors& colors)
+			: background(::CreateSolidBrush(colors.background))
+			, ctrlBackground(::CreateSolidBrush(colors.softerBackground))
+			, hotBackground(::CreateSolidBrush(colors.hotBackground))
+			, dlgBackground(::CreateSolidBrush(colors.pureBackground))
+			, errorBackground(::CreateSolidBrush(colors.errorBackground))
+
+			, edgeBrush(::CreateSolidBrush(colors.edge))
+			, hotEdgeBrush(::CreateSolidBrush(colors.hotEdge))
+			, disabledEdgeBrush(::CreateSolidBrush(colors.disabledEdge))
+		{
+		}
+
+		~Brushes()
+		{
+			::DeleteObject(background);			background = nullptr;
+			::DeleteObject(ctrlBackground);		ctrlBackground = nullptr;
+			::DeleteObject(hotBackground);		hotBackground = nullptr;
+			::DeleteObject(dlgBackground);		dlgBackground = nullptr;
+			::DeleteObject(errorBackground);	errorBackground = nullptr;
+
+			::DeleteObject(edgeBrush);			edgeBrush = nullptr;
+			::DeleteObject(hotEdgeBrush);		hotEdgeBrush = nullptr;
+			::DeleteObject(disabledEdgeBrush);	disabledEdgeBrush = nullptr;
+		}
+
+		void change(const Colors& colors)
+		{
+			::DeleteObject(background);
+			::DeleteObject(ctrlBackground);
+			::DeleteObject(hotBackground);
+			::DeleteObject(dlgBackground);
+			::DeleteObject(errorBackground);
+
+			::DeleteObject(edgeBrush);
+			::DeleteObject(hotEdgeBrush);
+			::DeleteObject(disabledEdgeBrush);
+
+			background = ::CreateSolidBrush(colors.background);
+			ctrlBackground = ::CreateSolidBrush(colors.softerBackground);
+			hotBackground = ::CreateSolidBrush(colors.hotBackground);
+			dlgBackground = ::CreateSolidBrush(colors.pureBackground);
+			errorBackground = ::CreateSolidBrush(colors.errorBackground);
+
+			edgeBrush = ::CreateSolidBrush(colors.edge);
+			hotEdgeBrush = ::CreateSolidBrush(colors.hotEdge);
+			disabledEdgeBrush = ::CreateSolidBrush(colors.disabledEdge);
+		}
+	};
+
+	struct Pens
+	{
+		HPEN darkerTextPen = nullptr;
+		HPEN edgePen = nullptr;
+		HPEN hotEdgePen = nullptr;
+		HPEN disabledEdgePen = nullptr;
+
+		Pens(const Colors& colors)
+			: darkerTextPen(::CreatePen(PS_SOLID, 1, colors.darkerText))
+			, edgePen(::CreatePen(PS_SOLID, 1, colors.edge))
+			, hotEdgePen(::CreatePen(PS_SOLID, 1, colors.hotEdge))
+			, disabledEdgePen(::CreatePen(PS_SOLID, 1, colors.disabledEdge))
+		{
+		}
+
+		~Pens()
+		{
+			::DeleteObject(darkerTextPen);		darkerTextPen = nullptr;
+			::DeleteObject(edgePen);			edgePen = nullptr;
+			::DeleteObject(hotEdgePen);			hotEdgePen = nullptr;
+			::DeleteObject(disabledEdgePen);	disabledEdgePen = nullptr;
+		}
+
+		void change(const Colors& colors)
+		{
+			::DeleteObject(darkerTextPen);
+			::DeleteObject(edgePen);
+			::DeleteObject(hotEdgePen);
+			::DeleteObject(disabledEdgePen);
+
+			darkerTextPen = ::CreatePen(PS_SOLID, 1, colors.darkerText);
+			edgePen = ::CreatePen(PS_SOLID, 1, colors.edge);
+			hotEdgePen = ::CreatePen(PS_SOLID, 1, colors.hotEdge);
+			disabledEdgePen = ::CreatePen(PS_SOLID, 1, colors.disabledEdge);
+		}
+
+	};
+
 }

--- a/src/NPP_DarkMode.h
+++ b/src/NPP_DarkMode.h
@@ -1,0 +1,39 @@
+/*
+	Copyright (C) 2025  Peter C. Jones <pryrtcode@pryrt.com>
+
+	This file is part of the source code for the CollectionInterface plugin for Notepad++
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#pragma once
+#include <windows.h>
+
+// extracted from https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/src/NppDarkMode.h
+namespace NppDarkMode {
+	struct Colors
+	{
+		COLORREF background = 0;
+		COLORREF softerBackground = 0; // ctrl background color
+		COLORREF hotBackground = 0;
+		COLORREF pureBackground = 0;   // dlg background color
+		COLORREF errorBackground = 0;
+		COLORREF text = 0;
+		COLORREF darkerText = 0;
+		COLORREF disabledText = 0;
+		COLORREF linkText = 0;
+		COLORREF edge = 0;
+		COLORREF hotEdge = 0;
+		COLORREF disabledEdge = 0;
+	};
+}

--- a/src/PluginDefinition.h
+++ b/src/PluginDefinition.h
@@ -90,5 +90,6 @@ extern FuncItem funcItem[nbFunc];
 //
 
 extern HWND g_hwndAboutDlg;
+extern HWND g_hwndCIDlg;
 
 #endif //PLUGINDEFINITION_H

--- a/src/PluginDefinition.h
+++ b/src/PluginDefinition.h
@@ -79,4 +79,16 @@ void showAboutModal();
 void showCollectionInterface();
 void showCIDownloadHelp();
 
+//
+// Need to expose the globals from PluginDefinition.cpp:
+//
+extern NppData nppData;
+extern FuncItem funcItem[nbFunc];
+
+//
+// My global variables
+//
+
+extern HWND g_hwndAboutDlg;
+
 #endif //PLUGINDEFINITION_H

--- a/src/PluginInterface.h
+++ b/src/PluginInterface.h
@@ -23,6 +23,7 @@
 
 #include "Scintilla.h"
 #include "Notepad_plus_msgs.h"
+#include "NPP_DarkMode.h"
 
 
 typedef const TCHAR * (__cdecl * PFUNCGETNAME)();

--- a/vs.proj/CollectionInterface.vcxproj
+++ b/vs.proj/CollectionInterface.vcxproj
@@ -195,7 +195,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;wininet.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;Comctl32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;wininet.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
     </Link>

--- a/vs.proj/CollectionInterface.vcxproj
+++ b/vs.proj/CollectionInterface.vcxproj
@@ -43,6 +43,7 @@
     <ClInclude Include="..\src\Hyperlinks.h" />
     <ClInclude Include="..\src\menuCmdID.h" />
     <ClInclude Include="..\src\Notepad_plus_msgs.h" />
+    <ClInclude Include="..\src\NPP_DarkMode.h" />
     <ClInclude Include="..\src\PluginDefinition.h" />
     <ClInclude Include="..\src\PluginInterface.h" />
     <ClInclude Include="..\src\Scintilla.h" />

--- a/vs.proj/CollectionInterface.vcxproj
+++ b/vs.proj/CollectionInterface.vcxproj
@@ -178,7 +178,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;wininet.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;Comctl32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;wininet.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -216,7 +216,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;wininet.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;Comctl32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;wininet.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -235,7 +235,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;wininet.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;Comctl32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;wininet.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImportLibrary>$(TargetName).lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
@@ -259,7 +259,7 @@ copy ..\README.md ..\bin\README.md</Command>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;wininet.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;Comctl32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;wininet.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImportLibrary>$(TargetName).lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
@@ -283,7 +283,7 @@ copy ..\README.md ..\bin64\README.md</Command>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;wininet.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;Comctl32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;wininet.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImportLibrary>$(TargetName).lib</ImportLibrary>
     </Link>
     <PostBuildEvent>

--- a/vs.proj/CollectionInterface.vcxproj.filters
+++ b/vs.proj/CollectionInterface.vcxproj.filters
@@ -1,35 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="..\src\DockingFeature\GoToLineDlg.cpp" />
-    <ClCompile Include="..\src\DockingFeature\StaticDialog.cpp" />
     <ClCompile Include="..\src\CollectionInterface.cpp" />
-    <ClCompile Include="..\src\PluginDefinition.cpp" />
     <ClCompile Include="..\src\Dialogs\AboutDialog.cpp">
       <Filter>Dialogs</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\Hyperlinks.cpp" />
     <ClCompile Include="..\src\Dialogs\CollectionInterfaceDialog.cpp">
       <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="..\src\Classes\CollectionInterfaceClass.cpp">
       <Filter>Classes</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\DockingFeature\GoToLineDlg.cpp">
+      <Filter>Ignore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\Hyperlinks.cpp">
+      <Filter>Libraries</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\PluginDefinition.cpp">
+      <Filter>Template</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\DockingFeature\StaticDialog.cpp">
+      <Filter>Template</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\DockingFeature\Docking.h" />
-    <ClInclude Include="..\src\DockingFeature\DockingDlgInterface.h" />
-    <ClInclude Include="..\src\DockingFeature\dockingResource.h" />
-    <ClInclude Include="..\src\DockingFeature\GoToLineDlg.h" />
-    <ClInclude Include="..\src\DockingFeature\resource.h" />
-    <ClInclude Include="..\src\DockingFeature\StaticDialog.h" />
-    <ClInclude Include="..\src\DockingFeature\Window.h" />
-    <ClInclude Include="..\src\menuCmdID.h" />
-    <ClInclude Include="..\src\Notepad_plus_msgs.h" />
-    <ClInclude Include="..\src\PluginDefinition.h" />
-    <ClInclude Include="..\src\PluginInterface.h" />
-    <ClInclude Include="..\src\Scintilla.h" />
-    <ClInclude Include="..\src\Sci_Position.h" />
     <ClInclude Include="..\src\Dialogs\AboutDialog.h">
       <Filter>Dialogs</Filter>
     </ClInclude>
@@ -39,7 +34,6 @@
     <ClInclude Include="..\src\Dialogs\Version.h">
       <Filter>Dialogs</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\Hyperlinks.h" />
     <ClInclude Include="..\src\Dialogs\CollectionInterfaceDialog.h">
       <Filter>Dialogs</Filter>
     </ClInclude>
@@ -49,15 +43,60 @@
     <ClInclude Include="..\src\Classes\json.hpp">
       <Filter>Classes</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\NPP_DarkMode.h" />
+    <ClInclude Include="..\src\DockingFeature\Docking.h">
+      <Filter>Ignore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\DockingFeature\DockingDlgInterface.h">
+      <Filter>Ignore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\DockingFeature\dockingResource.h">
+      <Filter>Ignore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\DockingFeature\GoToLineDlg.h">
+      <Filter>Ignore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\Hyperlinks.h">
+      <Filter>Libraries</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\menuCmdID.h">
+      <Filter>Template</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\Notepad_plus_msgs.h">
+      <Filter>Template</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\PluginDefinition.h">
+      <Filter>Template</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\PluginInterface.h">
+      <Filter>Template</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\DockingFeature\resource.h">
+      <Filter>Template</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\Sci_Position.h">
+      <Filter>Template</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\Scintilla.h">
+      <Filter>Template</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\DockingFeature\StaticDialog.h">
+      <Filter>Template</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\DockingFeature\Window.h">
+      <Filter>Template</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="..\src\DockingFeature\goLine.rc" />
     <ResourceCompile Include="..\src\CollectionInterface.rc" />
     <ResourceCompile Include="..\src\Dialogs\AboutDialog.rc">
       <Filter>Dialogs</Filter>
     </ResourceCompile>
     <ResourceCompile Include="..\src\Dialogs\CollectionInterfaceDialog.rc">
       <Filter>Dialogs</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="..\src\DockingFeature\goLine.rc">
+      <Filter>Ignore</Filter>
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
@@ -66,6 +105,15 @@
     </Filter>
     <Filter Include="Classes">
       <UniqueIdentifier>{8ebe3960-be3e-4cdd-92b3-097addd051c9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Ignore">
+      <UniqueIdentifier>{1c072973-cc48-4b01-b945-092e2b0abaa1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Libraries">
+      <UniqueIdentifier>{579b48be-0d6d-4835-8683-1b1bffb34634}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Template">
+      <UniqueIdentifier>{e69966f8-c062-412d-b317-3e2441889a05}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Get DarkMode working for all the dialogs, depending on version
- before 8.5.4, don't do dark mode calls at all (since there is no NPPM for that version)
- 8.5.4-8.8.1 (inclusive), do the NPPM _and_ do a local subclass for tab controls (because the NPPM in that range doesn't subclass tab-controls)
- v>8.8.1 (exclusive), just do the NPPM, because hopefully the updated message will handle it starting in next NPP release (if not, will need to change the threshold in the plugin)
